### PR TITLE
chore: fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,20 @@
     alt="License" />
   </a>
 </div>
+<div align="center">
+  <a href="https://ci.eclipse.org/dataspaceconnector/job/EDC-Snapshot">
+    <img src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fdataspaceconnector%2Fjob%2FEDC-Snapshot%2F&label=snapshot-build&style=flat-square"
+    alt="License" />
+  </a>
+  <a href="https://ci.eclipse.org/dataspaceconnector/job/EDC-Nightly-Snapshot">
+    <img src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fdataspaceconnector%2Fjob%2FEDC-Nightly-Snapshot%2F&label=nightly-build&style=flat-square"
+    alt="License" />
+  </a>
+</div>
 
 <p align="center">
   <a href="#contributing">Contribute</a> •
-  <a href="https://eclipse-dataspaceconnector.github.io/docs/">Docs</a> •
+  <a href="https://eclipse-dataspacecomponents.github.io/docs/">Docs</a> •
   <a href="https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues">Issues</a> •
   <a href="https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/LICENSE">License</a> •
   <a href="https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/1303">Q&A</a>

--- a/docs/developer/openapi.md
+++ b/docs/developer/openapi.md
@@ -78,7 +78,7 @@ However, if you leave it out, the Swagger Gradle Plugin will report an error.
 
 This feature does **neither** expose the generated files through a REST endpoint providing any sort of live try-out
 feature, **nor** does it generate any sort of client code. The static web content for Swagger UI is merely served
-through our [documentation page](https://eclipse-dataspaceconnector.github.io/docs/).
+through our [documentation page](https://eclipse-dataspacecomponents.github.io/docs/).
 
 However, the same gradle plugin we use for generating the static HTML content is also capable of generating client code.
 Please refer to the [official documentation](https://github.com/int128/gradle-swagger-generator-plugin).  


### PR DESCRIPTION
## What this PR changes/adds

Fix docs link after org renaming

## Why it does that

The link is broken

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
